### PR TITLE
Various fixes for node 0.12 + defaults for `debounce()`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
   - 0.12
-  - 0.4
-  - 0.5
+  - 4
+  - 5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - 0.12
+  - 0.4
+  - 0.5

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cerebral-addons
+# cerebral-addons [![Build Status](https://secure.travis-ci.org/coryvirok/cerebral-addons.png?branch=master)](https://travis-ci.org/coryvirok/cerebral-addons)
 
 An actions and factories utility belt for Cerebral.
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "prebuild": "npm run lint",
     "build": "rimraf lib && babel src --out-dir lib",
     "pretest": "npm run lint",
-    "test": "mocha --compilers js:babel/register --recursive",
+    "test": "mocha --compilers js:babel-core/register --recursive",
     "prepublish": "npm run build"
   },
   "repository": {
@@ -29,7 +29,7 @@
   "devDependencies": {
     "babel": "^6.3.26",
     "babel-cli": "^6.3.17",
-    "babel-core": "^6.3.26",
+    "babel-core": "^6.4.0",
     "babel-preset-es2015": "^6.3.13",
     "chai": "^3.4.1",
     "mocha": "^2.3.4",

--- a/src/factories/debounce.js
+++ b/src/factories/debounce.js
@@ -1,6 +1,6 @@
 const pending = {}
 
-export default function (time, continueChain, { terminateChain = [], immediate = true }) {
+export default function (time, continueChain, { terminateChain = [], immediate = true } = {}) {
   const id = Symbol('id')
 
   const timeout = function debounceTimeout () {

--- a/src/factories/stateToOutput.js
+++ b/src/factories/stateToOutput.js
@@ -10,7 +10,7 @@ export default function (statePath, outputPath) {
     let value = state.get(statePath)
     if (typeof value.toJS === 'function') {
       value = value.toJS()
-    } else if (Object.isFrozen(value)) {
+    } else if (value && value.constructor === Object && Object.isFrozen(value)) {
       value = JSON.parse(JSON.stringify(value))
     }
     setPathValue(input, outputPath, value)

--- a/src/factories/when.js
+++ b/src/factories/when.js
@@ -14,17 +14,22 @@ function when (path, outputs = { isTrue: truthy, isFalse: otherwise }, emptyObje
     }
 
     let otherwisePath = null
-    let outputPath = Object.keys(outputs).find(path => {
-      let test = outputs[path]
+    let outputPath
+    let test
+
+    for (let path in outputs) {
+      test = outputs[path]
       if (test === otherwise) {
         otherwisePath = path
-        return false
       } else {
-        return (test === value) ||
-        (test === truthy && value) ||
-        (test === falsy && !value)
+        if ((test === value) ||
+            (test === truthy && value) ||
+            (test === falsy && !value)) {
+          outputPath = path
+          break
+        }
       }
-    })
+    }
 
     args.output[outputPath || otherwisePath]()
   }

--- a/src/helpers/setValue.js
+++ b/src/helpers/setValue.js
@@ -12,7 +12,7 @@ export default function compile (path) {
         return function setOutputValue ({ input, output }, value) {
           const outputValue = (typeof value.toJS === 'function')
             ? value.toJS()
-            : Object.isFrozen(value)
+            : (value && value.constructor === Object && Object.isFrozen(value))
               ? JSON.parse(JSON.stringify(value))
               : value
           setPathValue(input, urlPath, outputValue)

--- a/test/factories/debounce.js
+++ b/test/factories/debounce.js
@@ -123,4 +123,33 @@ describe('debounce()', function () {
       chain[0](args)
     }, 15)
   })
+
+  it('should respect defaults', function (done) {
+    expectCount(1)
+    let terminated = 0
+    let continued = 0
+
+    const chain = debounce(10, [])
+
+    const args = {
+      output: {
+        continue () {
+          continued++
+          if (continued === 2) {
+            expect(terminated).to.equal(3)
+            done()
+          }
+        },
+        terminate () {
+          terminated++
+        }
+      }
+    }
+
+    chain[0](args)
+    chain[0](args)
+    chain[0](args)
+    chain[0](args)
+    chain[0](args)
+  })
 })


### PR DESCRIPTION
I also added in a Travis-CI config to keep an eye on the tests across node versions but you'll need to update it to point to the original repo, (it currently points to my fork.)