### PR TITLE
Add .babelrc to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@
 node_modules
 src
 test
+.babelrc

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cerebral-addons",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "An actions and factories utility belt for Cerebral",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
`.babelrc` is being published in npm which causes `.babelrc` of the project root not to be honored. This is problematic if you want to add `transform-runtime` to support new ES6 features like Symbols (without `transform-runtime` or global polyfill the code breaks in legacy browsers such as IE11). 